### PR TITLE
Added Difficulty to Dark Sight spell

### DIFF
--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -13,6 +13,7 @@
     "base_casting_time": 100,
     "base_energy_cost": 400,
     "energy_source": "MANA",
+    "difficulty": 6,
     "min_duration": 100000,
     "max_duration": 1000000,
     "duration_increment": 4500

--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -16,7 +16,7 @@
     "difficulty": 6,
     "min_duration": 100000,
     "max_duration": 1000000,
-    "duration_increment": 4500
+    "duration_increment": 2000
   },
   {
     "id": "megablast",
@@ -63,7 +63,7 @@
     "base_energy_cost": 500,
     "min_duration": 100000,
     "max_duration": 1000000,
-    "duration_increment": 4500
+    "duration_increment": 2000
   },
   {
     "id": "blinding_flash",


### PR DESCRIPTION
Was originally zero. Justifying the value chosen by the clairvoyance spell, which gives you instantaneous 1 turn vision on all tiles in the aoe based on level. Clairvoyance has difficulty 4. Whereas Dark Sight gives encumbrance-free light amp vision for the same amount of time as a magical light spell. Compared to the Magical Lamp spell which generates regular light at difficulty 2, for the same amount of time. Comparing the distance you gain in vision from light amp, difficulty 6 seems justified.

<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text (surrounded with <!–– and ––>) with text describing your PR.
NOTE: Please grant permission for repository maintainers to edit your PR.
It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Add difficulty to Dark Sight spell"

#### Purpose of change
Noticed while mucking around that Dark Sight had zero difficulty compared to a spell that was more expensive that merely gave you a magical night light for the same period of time. .<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```
If it *fully* resolves an issue, link it like: Fixes #1234
Even if the issue describes the problem, please provide a few-sentence summary here.
Example: Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
Don't put the backticks around the `#` and issue or pull request number to allow the GitHub automatically reference to it.
-->

#### Describe the solution
Change the difficulty to a value greater than zero. <!--
How does the feature work, or how does this fix a bug?
The easier you make your solution to understand, the faster it can get merged.
-->

#### Describe alternatives you've considered
Difficulty 4 or 5 would be fine too but 6 seemed more appropriate given that the tech solution is cheaper but encumbers you while the magical version has no encumbrance at all.<!--
A clear and concise description of any alternative solutions or features you've considered.
-->

#### Testing
<!--
Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.
Also include testing suggestions for reviewers and maintainers.
-->

Spell takes a little longer to learn and consequently trains Spellcraft higher but otherwise seems OK.

#### Additional context
The spell probably needs to cost more mana. At least as much as the Magical Light spell.<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.
-->
